### PR TITLE
feature: latency and value histograms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tic"
-version = "0.2.5-pre"
+version = "0.3.0-pre"
 authors = ["Brian Martin <brayniac@gmail.com>"]
 
 license = "MIT OR Apache-2.0"

--- a/examples/allan.rs
+++ b/examples/allan.rs
@@ -148,13 +148,16 @@ fn main() {
         .http_listen("localhost:42024".to_owned())
         .build();
 
-    receiver.add_interest(Interest::Waterfall(
+    receiver.add_interest(Interest::LatencyWaterfall(
         Metric::Ok,
         "ok_waterfall.png".to_owned(),
     ));
-    receiver.add_interest(Interest::Trace(Metric::Ok, "ok_trace.txt".to_owned()));
+    receiver.add_interest(Interest::LatencyTrace(
+        Metric::Ok,
+        "ok_trace.txt".to_owned(),
+    ));
     receiver.add_interest(Interest::Count(Metric::Ok));
-    receiver.add_interest(Interest::Percentile(Metric::Ok));
+    receiver.add_interest(Interest::LatencyPercentile(Metric::Ok));
     receiver.add_interest(Interest::AllanDeviation(Metric::Ok));
 
     let sender = receiver.get_sender();
@@ -183,16 +186,16 @@ fn main() {
 
         info!("rate: {} samples per second", r);
         info!(
-            "latency (ns): p50: {} p90: {} p999: {} p9999: {} max: {}",
-            m.percentile(&Metric::Ok, Percentile("p50".to_owned(), 50.0))
+            "phase offset (ns): p50: {} p90: {} p999: {} p9999: {} max: {}",
+            m.latency_percentile(&Metric::Ok, Percentile("p50".to_owned(), 50.0))
                 .unwrap_or(&0),
-            m.percentile(&Metric::Ok, Percentile("p90".to_owned(), 90.0))
+            m.latency_percentile(&Metric::Ok, Percentile("p90".to_owned(), 90.0))
                 .unwrap_or(&0),
-            m.percentile(&Metric::Ok, Percentile("p999".to_owned(), 99.9))
+            m.latency_percentile(&Metric::Ok, Percentile("p999".to_owned(), 99.9))
                 .unwrap_or(&0),
-            m.percentile(&Metric::Ok, Percentile("p9999".to_owned(), 99.99))
+            m.latency_percentile(&Metric::Ok, Percentile("p9999".to_owned(), 99.99))
                 .unwrap_or(&0),
-            m.percentile(&Metric::Ok, Percentile("max".to_owned(), 100.0))
+            m.latency_percentile(&Metric::Ok, Percentile("max".to_owned(), 100.0))
                 .unwrap_or(&0)
         );
         for t in 1..10 {

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -170,13 +170,16 @@ fn main() {
         .http_listen("localhost:42024".to_owned())
         .build();
 
-    receiver.add_interest(Interest::Waterfall(
+    receiver.add_interest(Interest::LatencyWaterfall(
         Metric::Ok,
         "ok_waterfall.png".to_owned(),
     ));
-    receiver.add_interest(Interest::Trace(Metric::Ok, "ok_trace.txt".to_owned()));
+    receiver.add_interest(Interest::LatencyTrace(
+        Metric::Ok,
+        "ok_trace.txt".to_owned(),
+    ));
     receiver.add_interest(Interest::Count(Metric::Ok));
-    receiver.add_interest(Interest::Percentile(Metric::Ok));
+    receiver.add_interest(Interest::LatencyPercentile(Metric::Ok));
 
     let sender = receiver.get_sender();
     let clocksource = receiver.get_clocksource();
@@ -210,15 +213,15 @@ fn main() {
         info!("rate: {} samples per second", r);
         info!(
             "latency (ns): p50: {} p90: {} p999: {} p9999: {} max: {}",
-            m.percentile(&Metric::Ok, Percentile("p50".to_owned(), 50.0))
+            m.latency_percentile(&Metric::Ok, Percentile("p50".to_owned(), 50.0))
                 .unwrap_or(&0),
-            m.percentile(&Metric::Ok, Percentile("p90".to_owned(), 90.0))
+            m.latency_percentile(&Metric::Ok, Percentile("p90".to_owned(), 90.0))
                 .unwrap_or(&0),
-            m.percentile(&Metric::Ok, Percentile("p999".to_owned(), 99.9))
+            m.latency_percentile(&Metric::Ok, Percentile("p999".to_owned(), 99.9))
                 .unwrap_or(&0),
-            m.percentile(&Metric::Ok, Percentile("p9999".to_owned(), 99.99))
+            m.latency_percentile(&Metric::Ok, Percentile("p9999".to_owned(), 99.99))
                 .unwrap_or(&0),
-            m.percentile(&Metric::Ok, Percentile("max".to_owned(), 100.0))
+            m.latency_percentile(&Metric::Ok, Percentile("max".to_owned(), 100.0))
                 .unwrap_or(&0)
         );
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,16 +1,31 @@
 #[derive(Clone, Eq, Hash, PartialEq)]
 /// an Interest registers a metric for reporting
 pub enum Interest<T> {
-    /// Calculate ADEV for the given metric
+    /// Calculate ADEV for the given metric based on the phase difference
+    /// between start and stop of each `Sample`. NOTE: It is expected that there
+    /// is 1 sample per second per metric
     AllanDeviation(T),
-    /// Keep a counter for the given metric
+    /// Keep a counter for the given metric, this is incremented by each count
+    /// associated with a `Sample`
     Count(T),
-    /// Calculate latency percentiles for metric
-    Percentile(T),
-    /// Creates a trace file of the latency heatmap
-    Trace(T, String),
-    /// Generate a PNG plot of the latency heatmaps
-    Waterfall(T, String),
+    /// Calculate latency percentiles for metric based on the delta between
+    /// start and stop time for each `Sample`
+    LatencyPercentile(T),
+    /// Calculate value percentiles for metric based on the counts associated
+    /// with each `Sample`
+    ValuePercentile(T),
+    /// Creates a trace file of the latency heatmaps which store the delta
+    /// between start and stop time for each `Sample`
+    LatencyTrace(T, String),
+    /// Generate a PNG plot of the latency heatmaps which store the delta
+    /// between start and stop time for each `Sample`
+    LatencyWaterfall(T, String),
+    /// Creates a trace file of the value heatmaps which store counts
+    /// asccociated with each `Sample`
+    ValueTrace(T, String),
+    /// Generate a PNG plot of the value heatmaps which store counts asccociated
+    /// with each `Sample`
+    ValueWaterfall(T, String),
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]

--- a/src/data/meters.rs
+++ b/src/data/meters.rs
@@ -40,8 +40,14 @@ impl<T: Hash + Eq + Send + Display + Clone> Meters<T> {
     }
 
     /// update the `Percentile` for a given metric
-    pub fn set_percentile(&mut self, channel: T, percentile: Percentile, value: u64) {
+    pub fn set_latency_percentile(&mut self, channel: T, percentile: Percentile, value: u64) {
         let key = format!("{}_{}_nanoseconds", channel, percentile.0);
+        self.data.insert(key, value);
+    }
+
+    /// update the `Percentile` for a given metric
+    pub fn set_value_percentile(&mut self, channel: T, percentile: Percentile, value: u64) {
+        let key = format!("{}_{}_units", channel, percentile.0);
         self.data.insert(key, value);
     }
 
@@ -57,9 +63,15 @@ impl<T: Hash + Eq + Send + Display + Clone> Meters<T> {
         self.data.get(&key)
     }
 
-    /// get the `Percentile` for a given metric
-    pub fn percentile(&self, channel: &T, percentile: Percentile) -> Option<&u64> {
+    /// get a `Percentile` of sample latencies for a given metric
+    pub fn latency_percentile(&self, channel: &T, percentile: Percentile) -> Option<&u64> {
         let key = format!("{}_{}_nanoseconds", channel, percentile.0);
+        self.data.get(&key)
+    }
+
+    /// get the `Percentile` of sample counts for a given metric
+    pub fn value_percentile(&self, channel: &T, percentile: Percentile) -> Option<&u64> {
+        let key = format!("{}_{}_units", channel, percentile.0);
         self.data.get(&key)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,10 @@
 //!         .build();
 //!
 //! // register some interests
+//! // record the counts of samples with `Metric::Ok`
 //! receiver.add_interest(Interest::Count(Metric::Ok));
-//! receiver.add_interest(Interest::Percentile(Metric::Ok));
+//! // record latency percentiles of samples with `Metric::Ok`
+//! receiver.add_interest(Interest::LatencyPercentile(Metric::Ok));
 //!
 //! // get a sender and a clocksource
 //! let mut sender = receiver.get_sender();


### PR DESCRIPTION
- 0.3.0-pre to reflect breaking changes to public API
- `Interest` enum is modified to support the notion of both latency and value histogram/heatmap storage
- `Receiver` modified to record both value and latency information to histograms/heatmaps
- `Meters` modified to allow access to both types of percentile
- update examples to work with newest API changes