### PR TITLE
build: remove 'asm' alias of rdtsc feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
       rust: nightly
       env: TYPE=features RUST_BACKTRACE=1
       script:
-        - cargo test --features asm
-        - cargo build --features asm
-        - cargo test --release --features asm
-        - cargo build --release --features asm
+        - cargo test --features rdtsc
+        - cargo build --features rdtsc
+        - cargo test --release --features rdtsc
+        - cargo build --release --features rdtsc
     - os: linux
       rust: stable
       env: TYPE=rustfmt RUST_BACKTRACE=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,3 @@ rand = "0.3.16"
 default = []
 benchmark = []
 rdtsc = ["clocksource/rdtsc"]
-asm = ["rdtsc"]


### PR DESCRIPTION
- removing the feature alias 'asm'->'rdtsc'