### PR TITLE
refactor: use SocketAddr to store listen address

### DIFF
--- a/examples/allan.rs
+++ b/examples/allan.rs
@@ -145,7 +145,7 @@ fn main() {
         .capacity(capacity)
         .batch_size(batch)
         .service(true)
-        .http_listen("localhost:42024".to_owned())
+        .http_listen("localhost:42024")
         .build();
 
     receiver.add_interest(Interest::LatencyWaterfall(

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -167,7 +167,7 @@ fn main() {
         .duration(duration)
         .capacity(capacity)
         .batch_size(batch)
-        .http_listen("localhost:42024".to_owned())
+        .http_listen("localhost:42024")
         .build();
 
     receiver.add_interest(Interest::LatencyWaterfall(


### PR DESCRIPTION
- refactor to use `SocketAddr` type to store the http listen address